### PR TITLE
Fix to remove the size differences between debug and release manifolds

### DIFF
--- a/include/manifolds/ValidManifold.h
+++ b/include/manifolds/ValidManifold.h
@@ -25,38 +25,34 @@ namespace mnf
 {
   class ValidManifold
   {
-#ifndef NDEBUG
   private:
     static const int FLAG = 1736274519; //a random number
   public:
     ValidManifold() : flag_(FLAG) {}
     ~ValidManifold() { flag_ = -271828182; }
 
-    bool isValid() const { return flag_ == FLAG; }
-
-    bool seeMessageAbove() const 
-    {
-#  ifndef MNF_ASSERT_THROW
-      printf("It appears that you're trying to call a method from a manifold that does not exist \
-anymore. Possible cause: the manifold was statically created in a scope (e.g. a function) which was \
-left since then. For Stan: https://www.youtube.com/watch?v=Yy8MUnlT9Oo\n"); 
-#  endif
-      return false; 
-    }
-  private:
-    int flag_;
-#else
-  public:
-    ValidManifold() {}
-    ~ValidManifold() {}
-
+#ifdef NDEBUG
     bool isValid() const { return true; }
 
     bool seeMessageAbove() const
     {
       return true;
     }
+#else
+    bool isValid() const { return flag_ == FLAG; }
+
+    bool seeMessageAbove() const
+    {
+#  ifndef MNF_ASSERT_THROW
+      printf("It appears that you're trying to call a method from a manifold that does not exist \
+             anymore. Possible cause: the manifold was statically created in a scope (e.g. a function) which was \
+             left since then. For Stan: https://www.youtube.com/watch?v=Yy8MUnlT9Oo\n"); 
+#  endif
+        return false;
+    }
 #endif
+  private:
+    int flag_;
   };
 }
 


### PR DESCRIPTION
As every function here is only used inside asserts (It is what I believe, correct me if I'm wrong about this), we could IMHO very well completely suppress the #ifdef debug macros behaviour, and only keep a single definition of the class.