### PR TITLE
Clean library generation in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,6 @@ include_directories(include)
 FIND_PACKAGE(Boost REQUIRED)
 include_directories(${Boost_INCLUDE_DIR})
 
-set(CMAKE_DEBUG_POSTFIX "_d")
-
 # add_subdirectory(bin)
 # add_subdirectory(share)
 add_subdirectory(src)


### PR DESCRIPTION
Removing the _d at the end of library names in debug.